### PR TITLE
refactor ElectionMap and add zooming

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "d3-array": "^2.0.3",
     "d3-scale": "^2.2.2",
     "d3-selection": "^1.4.0",
+    "d3-transition": "^1.2.0",
     "d3kit": "^3.2.0",
     "gatsby": "^2.1.31",
     "gatsby-plugin-emotion": "^4.0.6",

--- a/src/components/ElectionMap.js
+++ b/src/components/ElectionMap.js
@@ -4,6 +4,7 @@ import {
   select as d3Select,
   event as d3Event,
   mouse as d3Mouse,
+  zoom as d3Zoom,
 } from "d3"
 import { transition as d3Transition } from "d3"
 import { SvgChart, helper } from "d3kit"
@@ -84,8 +85,17 @@ class ElectionMap extends SvgChart {
         "transform",
         `translate(${this.getInnerWidth() / 2},${this.getInnerHeight() / 2})`
       )
+      .call(
+        d3Zoom()
+          .scaleExtent([1, 4])
+          .on("zoom", zoomed)
+      )
 
-    this.layers.get("center/zoom").attr("transform", "scale(1)")
+    const zoomLayer = this.layers.get("center/zoom")
+
+    function zoomed() {
+      zoomLayer.attr("transform", d3Event.transform)
+    }
 
     this.layers
       .get("center/zoom/map")
@@ -136,27 +146,24 @@ class ElectionMap extends SvgChart {
       .append("g")
       .style("transform", "scale(1)translate(0px, 0px)")
       .style("pointer-events", "bounding-box")
-
-    //hack for testing
-    // window.theMap = this;
   }
 
-  zoomIn() {
-    this.zoom = Math.min(this.zoom + 1, 3)
-    this.doZoom()
-  }
+  // zoomIn() {
+  //   this.zoom = Math.min(this.zoom + 1, 3)
+  //   this.doZoom()
+  // }
 
-  zoomOut() {
-    this.zoom = Math.max(this.zoom - 1, 1)
-    this.doZoom()
-  }
+  // zoomOut() {
+  //   this.zoom = Math.max(this.zoom - 1, 1)
+  //   this.doZoom()
+  // }
 
-  doZoom() {
-    this.layers
-      .get("center/zoom")
-      .transition()
-      .attr("transform", `scale(${this.zoom})`)
-  }
+  // doZoom() {
+  //   this.layers
+  //     .get("center/zoom")
+  //     .transition()
+  //     .attr("transform", `scale(${this.zoom})`)
+  // }
 
   visualize() {
     if (!this.hasNonZeroArea()) return

--- a/src/components/ElectionMap.js
+++ b/src/components/ElectionMap.js
@@ -1,14 +1,21 @@
-// import React from "react"
-import _ from "lodash"
-// import { transition as d3Transition } from "d3"
-import { select as d3Select, event as d3Event, mouse as d3Mouse } from "d3"
-import { transition as d3Transition } from "d3"
+import { keyBy } from "lodash"
+import {
+  quadtree,
+  select as d3Select,
+  event as d3Event,
+  mouse as d3Mouse,
+} from "d3"
+import { transition as d3Transition } from "d3" /*  */
 import { SvgChart, helper } from "d3kit"
 import { createComponent } from "react-d3kit"
 import { parties } from "../models/information"
 // import thMap from "../../public/th-grid-map.png"
-
 const maps = require("../models/information/_map.json")
+
+const partyLookup = keyBy(parties, p => p.id)
+
+const NO_PARTY = "#aaaaaa"
+const HIDDEN_ZONE = "#dddddd"
 
 // @todo #30 Declare the required props for Election Map.
 /**
@@ -35,23 +42,92 @@ class ElectionMap extends SvgChart {
   }
 
   static getCustomEventNames() {
-    return []
+    return ["cellClick"]
   }
 
   constructor(element, options) {
     super(element, options)
-    this.layers.create(["map", "label"])
+    this.layers.create({
+      center: { zoom: { map: ["cell", "label", "glass"] } },
+    })
+
+    this.zoom = 1
 
     this.visualize = this.visualize.bind(this)
     this.on("data", this.visualize)
     this.on("options", this.visualize)
-    this.on("resize", this.visualize)
-    this.margin(this.options().margin)
+    this.on("resize", () => {
+      this.layers
+        .get("center")
+        .attr(
+          "transform",
+          `translate(${this.getInnerWidth() / 2},${this.getInnerHeight() / 2})`
+        )
+
+      this.layers
+        .get("center/zoom/map")
+        .attr(
+          "transform",
+          `translate(${-this.getInnerWidth() / 2},${-this.getInnerHeight() /
+            2})`
+        )
+
+      this.visualize()
+    })
 
     // set up svg
-    this.svg.style("position", "relative").on("click", this.mapClick.bind(this))
+    this.svg.style("position", "relative")
+    // .on("click", this.mapClick.bind(this))
+
+    this.layers
+      .get("center")
+      .attr(
+        "transform",
+        `translate(${this.getInnerWidth() / 2},${this.getInnerHeight() / 2})`
+      )
+
+    this.layers.get("center/zoom").attr("transform", "scale(1)")
+
+    this.layers
+      .get("center/zoom/map")
+      .attr(
+        "transform",
+        `translate(${-this.getInnerWidth() / 2},${-this.getInnerHeight() / 2})`
+      )
+
+    this.glass = this.layers
+      .get("center/zoom/map/glass")
+      .append("rect")
+      .attr("fill", "rgba(0,0,0,0)")
+      .on("click", () => {
+        const [x, y] = d3Mouse(this.glass.node())
+        if (this.quadTree) {
+          const zone = this.quadTree.find(x, y, 32)
+
+          // clear previous seletion
+          const allZones = this.selection.selectAll("rect.zone")
+
+          allZones.transition().style("transform", "translate(0, 0)scale(1)")
+
+          if (zone) {
+            const { size, padding } = this.options()
+            const target = allZones.filter(d => d === zone)
+            target.raise()
+
+            target
+              .transition()
+              .style(
+                "transform",
+                `translate(${-zone.x - (size - padding) / 2}px, ${-zone.y -
+                  (size - padding) / 2}px)scale(2)`
+              )
+            this.options().onClick(zone)
+          }
+        }
+      })
+
     this.selection = this.layers
-      .get("map")
+      .get("center/zoom/map/cell")
       .attr("stroke", "none")
       .attr("stroke-width", 1)
       .attr("fill", "none")
@@ -61,6 +137,26 @@ class ElectionMap extends SvgChart {
       .append("g")
       .style("transform", "scale(1)translate(0px, 0px)")
       .style("pointer-events", "bounding-box")
+
+    //hack for testing
+    // window.theMap = this;
+  }
+
+  zoomIn() {
+    this.zoom = Math.min(this.zoom + 1, 3)
+    this.doZoom()
+  }
+
+  zoomOut() {
+    this.zoom = Math.max(this.zoom - 1, 1)
+    this.doZoom()
+  }
+
+  doZoom() {
+    this.layers
+      .get("center/zoom")
+      .transition()
+      .attr("transform", `scale(${this.zoom})`)
   }
 
   visualize() {
@@ -68,123 +164,75 @@ class ElectionMap extends SvgChart {
     this.render()
   }
 
-  color(d, data) {
-    const NO_PARTY = "#aaaaaa"
-    const HIDDEN_ZONE = "#dddddd"
-    const match = _.find(data, ["id", d.id])
+  color(d) {
+    const match = this.dataLookup[d.id]
     if (match) {
       if (!match.show) return HIDDEN_ZONE
-      const party = _.find(parties, ["id", match.partyId])
+      const party = partyLookup[match.partyId]
       return (party && party.color) || NO_PARTY
     }
     return NO_PARTY
   }
 
-  party(d, data) {
-    const match = _.find(data, ["id", d.id])
-    if (match) {
-      return match.partyId
-    }
-    return "-"
+  party(d) {
+    const match = this.dataLookup[d.id]
+    return match ? match.partyId : "-"
   }
 
-  radius(d, data) {
-    const match = _.find(data, ["id", d.id])
-    if (match) {
-      return match.complete ? this.options().size : 0
-    }
-    return 0
-  }
-
-  closestRect(point) {
-    let dmin = Infinity
-    let rect
-    const size = this.options().size
-    maps.zones.forEach(zone => {
-      const d = distance2(zone)
-      if (d < dmin) {
-        dmin = d
-        rect = zone
-      }
-    })
-    dmin = Math.sqrt(dmin)
-    return dmin < 32 ? rect : null
-
-    function distance2(p) {
-      var dx = p.x * size - point[0],
-        dy = p.y * size - point[1]
-      return dx * dx + dy * dy
-    }
-  }
-
-  mapClick(d, i) {
-    d3Event.stopPropagation()
-    let zone
-    if (!d) {
-      const x = d3Event.offsetX - 30.5
-      const y = d3Event.offsetY - 30.5
-      zone = this.closestRect([x, y])
-    } else {
-      zone = _.find(maps.zones, ["id", d.id])
-    }
-
-    // clear previous seletion
-    this.selection
-      .selectAll("rect.zone")
-      .style("transform", "translate(0, 0)scale(1)")
-
-    if (zone) {
-      const node = document.getElementById(zone.id)
-      const size = this.options().size
-      const padding = this.options().padding
-      const rect = d3Select(node)
-      rect.style(
-        "transform",
-        `translate(${-(zone.x * size) - (size - padding) / 2}px, ${-(
-          zone.y * size
-        ) -
-          (size - padding) / 2}px)scale(2)`
-      )
-      rect.raise()
-    }
-
-    this.options().onClick(d, i)
+  radius(d) {
+    const match = this.dataLookup[d.id]
+    return match && match.complete ? this.options().size : 0
   }
 
   render() {
-    const data = [...this.data()]
-    const size = this.options().size
-    const padding = this.options().padding
+    this.glass
+      .attr("width", this.getInnerWidth())
+      .attr("height", this.getInnerHeight())
 
+    this.dataLookup = keyBy(this.data(), d => d.id)
+    const { size, padding } = this.options()
     const t = d3Transition().duration(1000)
+
+    const zones = maps.zones.map(z => ({
+      x: z.x * size,
+      y: z.y * size,
+      data: z,
+    }))
+
+    const rectSide = size - padding
+
+    // Add center of the cell to quadtree
+    this.quadTree = quadtree()
+      .x(d => d.x + rectSide / 2)
+      .y(d => d.y + rectSide / 2)
+      .addAll(zones)
 
     const zoneSelection = this.selection
       .selectAll("rect.zone")
-      .data(maps.zones, d => d.id)
+      .data(zones, d => d.data.id)
     const zoneEnter = zoneSelection
       .enter()
       .append("rect")
       .classed("zone", true)
-      .attr("id", d => d.id)
-      .attr("data-p", d => this.party(d, data))
-      .attr("x", d => d.x * size)
-      .attr("y", d => d.y * size)
-      .attr("width", d => size - padding)
-      .attr("height", d => size - padding)
+      .attr("id", d => `zone-${d.data.id}`)
+      .attr("data-p", d => this.party(d.data))
+      .attr("x", d => d.x)
+      .attr("y", d => d.y)
+      .attr("width", rectSide)
+      .attr("height", rectSide)
       .style("transition", "all .2s ease-out")
       .style("transform", "translate(0, 0)scale(1)")
-      .on("click", this.mapClick.bind(this))
 
     zoneSelection
       .merge(zoneEnter)
       .transition(t)
-      .attr("fill", d => this.color(d, data))
-      .attr("rx", d => this.radius(d, data))
+      .attr("fill", d => this.color(d.data))
+      .attr("rx", d => this.radius(d.data))
 
     zoneSelection.exit().remove()
 
     const labelSelection = this.layers
-      .get("label")
+      .get("center/zoom/map/label")
       .attr("font-family", "BaiJamjuree-Regular, Bai Jamjuree")
       .attr("font-size", "6.4")
       .attr("font-weight", "normal")


### PR DESCRIPTION
* Remove usage of `_.find`. Create lookup instead
* Use `quadtree` for nearby lookup
* Add nested layer and basic zooming function. 

![election-live](https://user-images.githubusercontent.com/1659771/54807846-c39ae300-4c3b-11e9-859a-26531a179d8a.gif)

cc: @rapee 