### PR TITLE
Add area detail under zone number

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -246,6 +246,13 @@ function ZoneView({ provinceId, zoneNo }) {
                 }}
               />
             </h2>
+            <div
+              css={{
+                marginBottom: 10,
+              }}
+            >
+              {zone.details}
+            </div>
             <div>
               <span>นับแล้ว</span>
               <span


### PR DESCRIPTION
I added area detail under zone number according to this issue https://github.com/codeforthailand/election-live/issues/146.

### Screenshot
- 
<img width="331" alt="Screen Shot 2562-03-24 at 09 37 45" src="https://user-images.githubusercontent.com/26592279/54874195-cb63ae80-4e18-11e9-8602-d6bdc385cb5b.png">
