### PR TITLE
Add more provinces filters page

### DIFF
--- a/src/models/information/_filters.js
+++ b/src/models/information/_filters.js
@@ -1,4 +1,4 @@
-import { getProvinceById, getProvinceByName } from "."
+import { getProvinceById } from "."
 
 /** @type {IProvince[]} */
 const provinces = require("./_provinces.json")
@@ -80,15 +80,15 @@ const URBAN_ZONES = [
 
 const provinceFilter = function() {
   return provinces.reduce(
-    (acc, province) => ({
+    (acc, p) => ({
       ...acc,
-      [province.name]: {
+      [p.name]: {
         name: {
-          th: province.name,
-          en: province.name,
+          th: p.name,
+          en: p.name,
         },
         criterion: function(province, zone) {
-          return province.id === getProvinceByName(this.name.th).id
+          return province.id === p.id
         },
       },
     }),

--- a/src/models/information/_filters.js
+++ b/src/models/information/_filters.js
@@ -1,4 +1,7 @@
-import { getProvinceById } from "."
+import { getProvinceById, getProvinceByName } from "."
+
+/** @type {IProvince[]} */
+const provinces = require("./_provinces.json")
 
 // @ts-check
 
@@ -75,6 +78,24 @@ const URBAN_ZONES = [
   "10-17",
 ]
 
+const provinceFilter = function() {
+  return provinces.reduce(
+    (acc, province) => ({
+      ...acc,
+      [province.name]: {
+        name: {
+          th: province.name,
+          en: province.name,
+        },
+        criterion: function(province, zone) {
+          return province.id === getProvinceByName(this.name.th).id
+        },
+      },
+    }),
+    {}
+  )
+}
+
 /**
  * Available filters.
  *
@@ -83,6 +104,7 @@ const URBAN_ZONES = [
  * @type {{ [filterName in ZoneFilterName]: IZoneFilter }}
  */
 export const filters = {
+  ...provinceFilter(),
   all: {
     name: {
       th: "ทั่วประเทศ",

--- a/src/models/information/index.js
+++ b/src/models/information/index.js
@@ -51,6 +51,18 @@ export function getProvinceById(id) {
   return provincesMap.get(id) || fail(`Province ID ${id} not found`)
 }
 
+const provincesNameMap = new Map(
+  provinces.map(province => [province.name, province])
+)
+
+/**
+ * @param {string} name
+ * @returns {IProvince}
+ */
+export function getProvinceByName(name) {
+  return provincesNameMap.get(name) || fail(`Province name ${name} not found`)
+}
+
 const zoneMap = new Map(
   zones.map(zone => [zoneKey(zone.provinceId, zone.no), zone])
 )

--- a/src/models/information/index.js
+++ b/src/models/information/index.js
@@ -51,18 +51,6 @@ export function getProvinceById(id) {
   return provincesMap.get(id) || fail(`Province ID ${id} not found`)
 }
 
-const provincesNameMap = new Map(
-  provinces.map(province => [province.name, province])
-)
-
-/**
- * @param {string} name
- * @returns {IProvince}
- */
-export function getProvinceByName(name) {
-  return provincesNameMap.get(name) || fail(`Province name ${name} not found`)
-}
-
 const zoneMap = new Map(
   zones.map(zone => [zoneKey(zone.provinceId, zone.no), zone])
 )


### PR DESCRIPTION
I added more provinces filter pages according to this issue https://github.com/codeforthailand/election-live/issues/132.

hence, we can filter by the province in URL.

For example
- http://localhost:8000/filters/น่าน
- http://localhost:8000/filters/กรุงเทพมหานคร