### PR TITLE
fix bar chart in PartyStatsList

### DIFF
--- a/src/components/PartyStatsRow.js
+++ b/src/components/PartyStatsRow.js
@@ -1,43 +1,44 @@
 import React from "react"
+import { format } from "d3-format"
 import VisuallyHidden from "@reach/visually-hidden"
 import { DISPLAY_FONT } from "../styles"
 import { partyColor, partyLogo } from "../models/information"
+
+const formatPercent = format(".3%")
+
+const ARTICLE_STYLE = {
+  position: "relative",
+  marginBottom: "0.5rem",
+  padding: "0.5rem 0",
+  display: "grid",
+  gridTemplateColumns: "28px auto 32px",
+  gridGap: "6px",
+  background: "white",
+}
+
+const PARTY_NAME_STYLE = {
+  margin: 0,
+  fontSize: "1.5rem",
+  fontFamily: DISPLAY_FONT,
+  whiteSpace: "nowrap",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+}
 
 /**
  * @param {{ party: IParty, constituencySeats: number, partyListSeats: number, maxSeats: number, filtered: boolean }} props
  */
 const PartyStatsRow = props => {
   const totalSeats = props.constituencySeats + props.partyListSeats
-  const barWidth = `${(totalSeats / props.maxSeats).toFixed(4)}`
+  const barWidth = totalSeats / props.maxSeats
 
   return (
-    <article
-      css={{
-        position: "relative",
-        marginBottom: "0.5rem",
-        padding: "0.5rem 0",
-        display: "grid",
-        gridTemplateColumns: "28px auto 32px",
-        gridGap: "6px",
-        background: "white",
-      }}
-    >
+    <article css={ARTICLE_STYLE}>
       <div>
         <img alt="" src={partyLogo(props.party.name)} width="28" />
       </div>
       <div css={{ overflow: "hidden" }}>
-        <h3
-          css={{
-            margin: 0,
-            fontSize: "1.5rem",
-            fontFamily: DISPLAY_FONT,
-            whiteSpace: "nowrap",
-            textOverflow: "ellipsis",
-            overflow: "hidden",
-          }}
-        >
-          {props.party.name}
-        </h3>
+        <h3 css={PARTY_NAME_STYLE}>{props.party.name}</h3>
         <div css={{ margin: 0 }}>
           ส.ส. เขต: {props.constituencySeats}
           <VisuallyHidden> ที่นั่ง </VisuallyHidden>
@@ -48,17 +49,14 @@ const PartyStatsRow = props => {
             </React.Fragment>
           )}
         </div>
-        <div
-          css={{
-            height: 5,
-            marginTop: "5px",
-            transformOrigin: "left",
-          }}
-          style={{
-            transform: `scaleX(${barWidth})`,
-            background: partyColor(props.party),
-          }}
-        />
+        <svg width="100%" height="5">
+          <rect width="100%" height="5" fill="#ccc" />
+          <rect
+            width={formatPercent(barWidth)}
+            height="5"
+            fill={partyColor(props.party)}
+          />
+        </svg>
       </div>
       <div>
         <VisuallyHidden> ทั้งหมด </VisuallyHidden>


### PR DESCRIPTION
When displaying percentage with bar chart, it is important to know where 100% is.
This PR adds gray bg behind the main bar to indicate entire range.

![image](https://user-images.githubusercontent.com/1659771/54876710-98e29300-4dd1-11e9-8552-c1320e6a1820.png)
