### PR TITLE
:bug: Fix map tooltip error when the position is not found

### DIFF
--- a/src/components/ElectionMapTooltip.js
+++ b/src/components/ElectionMapTooltip.js
@@ -24,6 +24,8 @@ const LARGE_FONT = { fontSize: "1.1rem" }
 export default function ElectionMapTooltip({ positionId, positions }) {
   const memo = useMemo(() => {
     const position = _.find(positions, p => p.id == positionId)
+    if (!position) return {}
+
     const party = partyLookup[position.partyId]
     const matchZone = positionId.match(/^(\d+)-(\d+)$/)
     if (matchZone) {


### PR DESCRIPTION
When the `position` variable is null, it causes the election map to display an error. We should check whether the position is present before accessing the `partyId`.