### PR TITLE
Edit party list description in ElectionMapTooltip

### DIFF
--- a/src/components/ElectionMapTooltip.js
+++ b/src/components/ElectionMapTooltip.js
@@ -12,6 +12,7 @@ import loadingSmall from "../styles/images/loading.gif"
 import ZoneMark from "./ZoneMark"
 import PercentBarChart from "./PercentBarChart"
 import { useSummaryData } from "../models/LiveDataSubscription"
+import { nationwidePartyStatsFromSummaryJSON } from "../models/PartyStats"
 import _ from "lodash"
 
 const partyLookup = keyBy(parties, d => d.id)
@@ -56,6 +57,7 @@ export default function ElectionMapTooltip({ positionId, positions }) {
   let percentage = 0
   let noVotesWin = false
   let noProgress = true
+  let partyStat
   if (zone && completed) {
     const { zoneWinningCandidateMap = {}, zoneStatsMap = {} } = data || {}
     const { no, provinceId } = zone
@@ -75,6 +77,8 @@ export default function ElectionMapTooltip({ positionId, positions }) {
       }
     }
   } else if (seat) {
+    const partyStats = nationwidePartyStatsFromSummaryJSON(data)
+    partyStat = _.find(partyStats, { party: { id: party.id } })
     markColor = party ? party.color : "#ccc"
   }
 
@@ -109,8 +113,8 @@ export default function ElectionMapTooltip({ positionId, positions }) {
                 <div style={LARGE_FONT}>
                   <b>ส.ส. บัญชีรายชื่อ</b>
                 </div>
-                <div>อันดับที่ {seat.no}</div>
                 <div>{party ? `พรรค${party.name}` : null}</div>
+                <div>{partyStat.partyListSeats} ที่นั่ง</div>
               </div>
             )}
           </td>


### PR DESCRIPTION
ref #214

From seat no.
<img width="239" alt="Screenshot 2019-03-25 at 02 54 28" src="https://user-images.githubusercontent.com/13469652/54884984-b2efa480-4ea9-11e9-906d-894887a16869.png">,

to the number of seats of each party
<img width="231" alt="Screenshot 2019-03-25 at 02 54 22" src="https://user-images.githubusercontent.com/13469652/54884985-b3883b00-4ea9-11e9-9bba-a9b5aa155f7f.png">.

NB there might be a faster way to query the numbers, instead of nationwidePartyStatsFromSummaryJSON(), that I'm unaware of.
