### PR TITLE
Add warning message for abnormal vote counts

### DIFF
--- a/src/components/TotalVoterSummary.js
+++ b/src/components/TotalVoterSummary.js
@@ -47,6 +47,13 @@ export default function TotalVoterSummary(props) {
         >
           <AnimatedNumber value={totalVotePercentage} initialValue={0} />%
         </span>
+        {totalVotePercentage > 100 ? (
+          <div
+            css={{ textAlign: "center", color: "#F0324B", fontStyle: "italic" }}
+          >
+            พบความผิดปกติ รอการตรวจสอบอีกครั้ง
+          </div>
+        ) : null}
       </div>
     )
   }


### PR DESCRIPTION
There are myriads of abnormalities in the results. This exceeding number of vote counts is one of them. I suggest that we should warn the viewer that this weird result is probably incorrect. 

<img width="366" alt="Screenshot 2019-03-25 at 03 23 40" src="https://user-images.githubusercontent.com/13469652/54885339-948ba800-4ead-11e9-9a4f-b1ef3bb94537.png">
