### PR TITLE
Fixes #232: make the panel stay open on refocus

### DIFF
--- a/src/components/TimeMachine.js
+++ b/src/components/TimeMachine.js
@@ -39,8 +39,10 @@ export function TimeMachine() {
   }
   const goBackTo = index => {
     const directory = dirs[index][0]
-    trackEvent("Time Machine", { dir: directory })
-    setOverride(directory)
+    if (directory !== override) {
+      trackEvent("Time Machine", { dir: directory })
+      setOverride(directory)
+    }
   }
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown)

--- a/src/components/TimeMachine.js
+++ b/src/components/TimeMachine.js
@@ -40,7 +40,7 @@ export function TimeMachine() {
   const goBackTo = index => {
     const directory = dirs[index][0]
     trackEvent("Time Machine", { dir: directory })
-    setOverride(directory === override ? null : directory)
+    setOverride(directory)
   }
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown)


### PR DESCRIPTION
Prior this PR, when we refocus an entry in the time machine panel, either by
- clicking at the same entry; or
- press left (or right) key at the first (or last) entry

the panel will be deactivated. This causes a bad user experience because it's very easy to accidentally refocus. This PR fixes the issue by preventing the panel deactivation on refocusing.