### PR TITLE
Add พลังปวงชนไทย to anti-NCPO group

### DIFF
--- a/src/models/information/_parties.json
+++ b/src/models/information/_parties.json
@@ -424,7 +424,8 @@
     "color": "#181f97",
     "id": 75,
     "name": "พลังปวงชนไทย",
-    "partylist": 62
+    "partylist": 62,
+    "supportNcpo": false
   },
   {
     "codeEN": "PTRT",


### PR DESCRIPTION
According to [the announcement in the morning of 27 March](https://www.facebook.com/pheuthaiparty/videos/2643490755722162/), พลังปวงชนไทย has joined the pro-democracy side.