### PR TITLE
Fix party list map tooltip on historical data

### DIFF
--- a/src/components/ElectionMapTooltip.js
+++ b/src/components/ElectionMapTooltip.js
@@ -76,9 +76,11 @@ export default function ElectionMapTooltip({ positionId, positions }) {
         markColor = partyColor(getPartyById(candidate.partyId))
       }
     }
-  } else if (seat) {
-    const partyStats = nationwidePartyStatsFromSummaryJSON(data)
-    partyStat = _.find(partyStats, { party: { id: party.id } })
+  } else if (seat && completed) {
+    if (!!party) {
+      const partyStats = nationwidePartyStatsFromSummaryJSON(data)
+      partyStat = _.find(partyStats, { party: { id: party.id } })
+    }
     markColor = party ? party.color : "#ccc"
   }
 
@@ -113,8 +115,14 @@ export default function ElectionMapTooltip({ positionId, positions }) {
                 <div style={LARGE_FONT}>
                   <b>ส.ส. บัญชีรายชื่อ</b>
                 </div>
-                <div>{party ? `พรรค${party.name}` : null}</div>
-                <div>{partyStat.partyListSeats} ที่นั่ง</div>
+                {party && completed ? (
+                  <div>
+                    <div>{party ? `พรรค${party.name}` : null}</div>
+                    <div>{partyStat.partyListSeats} ที่นั่ง</div>
+                  </div>
+                ) : (
+                  <div>อันดับที่ {seat.no}</div>
+                )}
               </div>
             )}
           </td>


### PR DESCRIPTION
When there is no party assigned to a party list seat, i.e., historical data with phantom votes, a tooltip is to show the number of the seat, as previously used before #214 & #220.

Error:
<img width="376" alt="Screenshot 2019-03-27 at 15 09 41" src="https://user-images.githubusercontent.com/13469652/55060126-5657d980-50a3-11e9-8157-4428fd8b9275.png">,
Fixed:
<img width="339" alt="Screenshot 2019-03-27 at 15 09 31" src="https://user-images.githubusercontent.com/13469652/55060128-5657d980-50a3-11e9-875a-56a844ed4a2e.png">
